### PR TITLE
add contentType pdf to import options

### DIFF
--- a/chrome/content/scripts/zoteroscihub.js
+++ b/chrome/content/scripts/zoteroscihub.js
@@ -181,7 +181,9 @@ Zotero.Scihub = {
 						if (item.isRegularItem() && !item.isCollection()) {
 							try {
 								// Extract direct pdf url from scihub webpage.
-								var split_html = req.responseText.split('<iframe src = "')
+								var html_text = req.responseText
+								html_text = html_text.replace(/\s/g, "")
+								var split_html = html_text.split('<iframesrc="')
 								pdf_url = split_html[1].split('"')[0]
 								pdf_url = Zotero.Scihub.fixPdfUrl(pdf_url);
 
@@ -200,6 +202,7 @@ Zotero.Scihub = {
 									parentItemID: item.id,
 									title: item.getField('title'),
 									fileBaseName: fileBaseName,
+									contentType: 'application/pdf',
 									referrer: '',
 									cookieSandbox: null
 								};


### PR DESCRIPTION
- this fix updates the extract of URL to download pdf. It did not work for sci-hub.shop due to different spacing.
- this fix adds a "contentType" option to pdf into the import options so that Zotero can handle it correctly.