### PR TITLE
Update DOI extraction from item

### DIFF
--- a/chrome/content/scripts/zoteroscihub.js
+++ b/chrome/content/scripts/zoteroscihub.js
@@ -1,50 +1,50 @@
 Zotero.Scihub = {
-	scihub_url: function() {
+	scihub_url: function () {
 		// Set default if not set.
-		if(Zotero.Prefs.get('zoteroscihub.scihub_url') === undefined) {
+		if (Zotero.Prefs.get('zoteroscihub.scihub_url') === undefined) {
 			Zotero.Prefs.set('zoteroscihub.scihub_url', 'https://sci-hub.do/')
 		}
 		return Zotero.Prefs.get('zoteroscihub.scihub_url')
 	},
-	automatic_pdf_download: function() {
+	automatic_pdf_download: function () {
 		// Set default if not set.
-		if(Zotero.Prefs.get('zoteroscihub.automatic_pdf_download') === undefined) {
+		if (Zotero.Prefs.get('zoteroscihub.automatic_pdf_download') === undefined) {
 			Zotero.Prefs.set('zoteroscihub.automatic_pdf_download', true)
 		}
 		return Zotero.Prefs.get('zoteroscihub.automatic_pdf_download')
 	},
-	init: function() {
+	init: function () {
 		Zotero.Scihub.resetState();
 		Zotero.Scihub.scihub_url();
 		Zotero.Scihub.automatic_pdf_download();
 
 		// Register the callback in Zotero as an item observer
 		var notifierID = Zotero.Notifier.registerObserver(
-						Zotero.Scihub.notifierCallback, ['item']);
+			Zotero.Scihub.notifierCallback, ['item']);
 
 		// Unregister callback when the window closes (important to avoid a memory leak)
-		window.addEventListener('unload', function(e) {
-				Zotero.Notifier.unregisterObserver(notifierID);
+		window.addEventListener('unload', function (e) {
+			Zotero.Notifier.unregisterObserver(notifierID);
 		}, false);
 	},
 	notifierCallback: {
 		// Adds pdfs when new item is added to zotero.
-		notify: function(event, type, ids, extraData) {
+		notify: function (event, type, ids, extraData) {
 			automatic_pdf_download_bool = Zotero.Prefs.get('zoteroscihub.automatic_pdf_download');
-	    if(event == "add" && !(automatic_pdf_download_bool === undefined) && automatic_pdf_download_bool == true) {
+			if (event == "add" && !(automatic_pdf_download_bool === undefined) && automatic_pdf_download_bool == true) {
 				suppress_warnings = true;
-	      Zotero.Scihub.updateItems(Zotero.Items.get(ids), suppress_warnings);
-	    }
-	  }
+				Zotero.Scihub.updateItems(Zotero.Items.get(ids), suppress_warnings);
+			}
+		}
 	},
-	resetState: function() {
+	resetState: function () {
 		// Reset state for updating items.
 		Zotero.Scihub.current = -1;
 		Zotero.Scihub.toUpdate = 0;
 		Zotero.Scihub.itemsToUpdate = null;
 		Zotero.Scihub.numberOfUpdatedItems = 0;
 	},
-	updateSelectedEntity: function(libraryId) {
+	updateSelectedEntity: function (libraryId) {
 		Zotero.debug('Updating items in entity')
 		if (!ZoteroPane.canEdit()) {
 			ZoteroPane.displayCannotEditLibraryMessage();
@@ -63,12 +63,12 @@ Zotero.Scihub = {
 			Zotero.Scihub.updateItems(items, suppress_warnings);
 		}
 	},
-	updateSelectedItems: function() {
+	updateSelectedItems: function () {
 		Zotero.debug('Updating Selected items');
 		suppress_warnings = false;
 		Zotero.Scihub.updateItems(ZoteroPane.getSelectedItems(), suppress_warnings);
 	},
-	updateAll: function() {
+	updateAll: function () {
 		Zotero.debug('Updating all items in Zotero')
 		var items = [];
 
@@ -78,13 +78,13 @@ Zotero.Scihub = {
 				// Once we have all items, make sure it's a regular item.
 				// And that the library is editable
 				// Then add that item to our list.
-				items.map(function(item) {
+				items.map(function (item) {
 					if (item.isRegularItem() && !item.isCollection()) {
 						var libraryId = item.getField('libraryID');
 						if (libraryId == null ||
-								libraryId == '' ||
-								Zotero.Libraries.isEditable(libraryId)) {
-									items.push(item);
+							libraryId == '' ||
+							Zotero.Libraries.isEditable(libraryId)) {
+							items.push(item);
 						}
 					}
 				});
@@ -94,11 +94,11 @@ Zotero.Scihub = {
 		suppress_warnings = true;
 		Zotero.Scihub.updateItems(items, suppress_warnings);
 	},
-	updateItems: function(items, suppress_warnings) {
+	updateItems: function (items, suppress_warnings) {
 		// If we don't have any items to update, just return.
 		if (items.length == 0 ||
-				Zotero.Scihub.numberOfUpdatedItems < Zotero.Scihub.toUpdate) {
-				return;
+			Zotero.Scihub.numberOfUpdatedItems < Zotero.Scihub.toUpdate) {
+			return;
 		}
 
 		// Reset our state and figure out how many items we have to update.
@@ -108,29 +108,39 @@ Zotero.Scihub = {
 		// Iterate through our items, updating each one with a pdf.
 		Zotero.Scihub.updateNextItem(suppress_warnings);
 	},
-	updateNextItem: function(suppress_warnings) {
+	updateNextItem: function (suppress_warnings) {
 		Zotero.Scihub.numberOfUpdatedItems++;
 
 		// If we have updated all of our items, reset our state and return.
 		if (Zotero.Scihub.current == Zotero.Scihub.toUpdate - 1) {
-				Zotero.Scihub.resetState();
-				return;
+			Zotero.Scihub.resetState();
+			return;
 		}
 
 		// Update a single item with a pdf.
 		Zotero.Scihub.current++;
 		Zotero.Scihub.updateItem(
-						Zotero.Scihub.itemsToUpdate[Zotero.Scihub.current],
-						suppress_warnings
+			Zotero.Scihub.itemsToUpdate[Zotero.Scihub.current],
+			suppress_warnings
 		);
 	},
-	generateItemUrl: function(item) {
+	generateItemUrl: function (item) {
 		var baseURL = Zotero.Prefs.get('zoteroscihub.scihub_url')
 		var DOI = item.getField('DOI').length > 0 ? item.getField('DOI') : item.getField('extra');
-		DOI = DOI.indexOf("\n")> -1 ? DOI.substring(DOI.indexOf('DOI: '), DOI.indexOf("\n", DOI.indexOf('DOI: '))).replace('DOI: ', '') : DOI.replace('DOI: ', '');
+		Zotero.debug(DOI);
+		if (DOI.indexOf('\n', DOI.indexOf('DOI: ')) > -1) {
+			Zotero.debug('DOI is not at the last line');
+			DOI = DOI.substring(DOI.indexOf('DOI: '), DOI.indexOf('\n', DOI.indexOf('DOI: ')));
+		}
+		else {
+			Zotero.debug('DOI is at the last line');
+			DOI = DOI.substring(DOI.indexOf('DOI: '), DOI.length);
+		}
+		DOI = DOI.replace('DOI: ', '');
+		Zotero.debug('Extracted DOI: ' + DOI);
 		var url = "";
-		if(DOI && (typeof DOI == 'string') && DOI.length > 0) {
-			url = baseURL+'/'+DOI;
+		if (DOI && (typeof DOI == 'string') && DOI.length > 0) {
+			url = baseURL + '/' + DOI;
 		}
 
 		// If not using sci-hub.tw ssl is disabled due to invalid certs.
@@ -140,7 +150,7 @@ Zotero.Scihub = {
 
 		return url;
 	},
-	fixPdfUrl: function(pdf_url) {
+	fixPdfUrl: function (pdf_url) {
 		let prepend = "https"
 		// Check if user preferred url is using https. If so, prepend/replace https.
 		// If not prepend/replace http.
@@ -150,12 +160,12 @@ Zotero.Scihub = {
 		// }
 
 		// Handle error on Scihub where https/http is not prepended to url
-		if(pdf_url.slice(0, 2) == "//") {
+		if (pdf_url.slice(0, 2) == "//") {
 			pdf_url = prepend + ":" + pdf_url
 		}
 
 		// Make sure all scihub urls use https/http and not http.
-		if(pdf_url.slice(0, 5) != "https") {
+		if (pdf_url.slice(0, 5) != "https") {
 			pdf_url = prepend + pdf_url.slice(4)
 		}
 
@@ -166,35 +176,35 @@ Zotero.Scihub = {
 
 		return pdf_url;
 	},
-	updateItem: function(item, suppress_warnings) {
+	updateItem: function (item, suppress_warnings) {
 		Zotero.debug("Suppress: " + suppress_warnings)
 		var url2 = Zotero.Scihub.generateItemUrl(item);
 		var pdf_url = "";
 		var req = new XMLHttpRequest();
-		var url = url2.replace(".tw",".do");
+		var url = url2.replace(".tw", ".do");
 
 		Zotero.debug('Opening ' + url);
-		if(url != "") {
+		if (url != "") {
 			req.open('GET', url, true);
 			req.responseType = "document";
-			req.onreadystatechange = function() {
+			req.onreadystatechange = function () {
 				if (req.readyState == 4) {
 					if (req.status == 200 && req.responseXML.querySelector("iframe#pdf") !== null
-					/* && req.responseText.search("captcha") == -1 */ ) {
+					/* && req.responseText.search("captcha") == -1 */) {
 						if (item.isRegularItem() && !item.isCollection()) {
 							try {
 								// Extract direct pdf url from scihub webpage.
 								pdf_url = req.responseXML.querySelector("iframe#pdf").src
-								Zotero.debug('Got pdf_url from embedding page: '+pdf_url);
+								Zotero.debug('Got pdf_url from embedding page: ' + pdf_url);
 								pdf_url = Zotero.Scihub.fixPdfUrl(pdf_url);
-								Zotero.debug('After fixPdfUrl, getting pdf_url: '+ pdf_url);
+								Zotero.debug('After fixPdfUrl, getting pdf_url: ' + pdf_url);
 
 								// Extract PDF name.
 								// var pdf_url_obj = new URL(pdf_url),
 								fileBaseName = pdf_url.split('/').pop();
-							} catch(e) {
+							} catch (e) {
 								Zotero.debug("Error parsing webpage 1" + e);
-								alert('Error parsing webpage 1, got error: '+ e);
+								alert('Error parsing webpage 1, got error: ' + e);
 
 							}
 
@@ -212,10 +222,10 @@ Zotero.Scihub = {
 								};
 								Zotero.debug("Import Options: " + JSON.stringify(import_options, null, "\t"));
 								Zotero.Attachments.importFromURL(import_options)
-									.then(function(result) {
+									.then(function (result) {
 										Zotero.debug("Import result: " + JSON.stringify(result))
 									})
-									.catch(function(error) {
+									.catch(function (error) {
 										Zotero.debug("Import error: " + error)
 										// See the following code, if Scihub throws a captcha then our import will throw this error.
 										// https://github.com/zotero/zotero/blob/26056c87f1d0b31dc56981adaabcab8fc2f85294/chrome/content/zotero/xpcom/attachments.js#L863
@@ -224,23 +234,23 @@ Zotero.Scihub = {
 										alert('Please enter the Captcha on the page that will now open and then re-try updating the PDFs, or wait a while to get unblocked by Scihub if the Captcha is not present.');
 										req2 = new XMLHttpRequest();
 										req2.open('GET', pdf_url, true);
-										req2.onreadystatechange = function() {
-										 if (req2.readyState == 4) {
-											 if (typeof Zotero.launchURL !== 'undefined') {
-												 Zotero.launchURL(pdf_url);
-											 } else if (typeof Zotero.openInViewer !== 'undefined') {
-												 Zotero.openInViewer(pdf_url);
-											 } else if (typeof ZoteroStandalone !== 'undefined') {
-												 ZoteroStandalone.openInViewer(pdf_url);
-											 } else {
-												 window.gBrowser.loadOneTab(pdf_url, {inBackground: false});
-											 }
-											 Zotero.Scihub.resetState();
-										 }
+										req2.onreadystatechange = function () {
+											if (req2.readyState == 4) {
+												if (typeof Zotero.launchURL !== 'undefined') {
+													Zotero.launchURL(pdf_url);
+												} else if (typeof Zotero.openInViewer !== 'undefined') {
+													Zotero.openInViewer(pdf_url);
+												} else if (typeof ZoteroStandalone !== 'undefined') {
+													ZoteroStandalone.openInViewer(pdf_url);
+												} else {
+													window.gBrowser.loadOneTab(pdf_url, { inBackground: false });
+												}
+												Zotero.Scihub.resetState();
+											}
 										}
 										req2.send(null);
 									});
-							} catch(e) {
+							} catch (e) {
 								Zotero.debug("Error creating attachment: " + e)
 							}
 						}
@@ -252,7 +262,7 @@ Zotero.Scihub = {
 						alert(Zotero.Scihub.captchaString);
 						req2 = new XMLHttpRequest();
 						req2.open('GET', url, true);
-						req2.onreadystatechange = function() {
+						req2.onreadystatechange = function () {
 							if (req2.readyState == 4) {
 								if (typeof Zotero.launchURL !== 'undefined') {
 									Zotero.launchURL(url);
@@ -261,7 +271,7 @@ Zotero.Scihub = {
 								} else if (typeof ZoteroStandalone !== 'undefined') {
 									ZoteroStandalone.openInViewer(url);
 								} else {
-									window.gBrowser.loadOneTab(url, {inBackground: false});
+									window.gBrowser.loadOneTab(url, { inBackground: false });
 								}
 								Zotero.Scihub.resetState();
 							}
@@ -271,13 +281,13 @@ Zotero.Scihub = {
 				}
 			};
 			req.send(null);
-		} else if(!(suppress_warnings === undefined) && suppress_warnings == false){
+		} else if (!(suppress_warnings === undefined) && suppress_warnings == false) {
 			alert("To be able to fetch a PDF your library item must currently have a DOI")
 		}
 
 	}
 };
 
-window.addEventListener('load', function(e) {
-  Zotero.Scihub.init();
+window.addEventListener('load', function (e) {
+	Zotero.Scihub.init();
 }, false);

--- a/chrome/content/scripts/zoteroscihub.js
+++ b/chrome/content/scripts/zoteroscihub.js
@@ -126,7 +126,8 @@ Zotero.Scihub = {
 	},
 	generateItemUrl: function(item) {
 		var baseURL = Zotero.Prefs.get('zoteroscihub.scihub_url')
-		var DOI = item.getField('DOI');
+		var DOI = item.getField('DOI').length > 0 ? item.getField('DOI') : item.getField('extra');
+		DOI = DOI.indexOf("\n")> -1 ? DOI.substring(0, DOI.indexOf("\n")).replace('DOI: ', '') : DOI.replace('DOI: ', '');
 		var url = "";
 		if(DOI && (typeof DOI == 'string') && DOI.length > 0) {
 			url = baseURL+'/'+DOI;

--- a/chrome/content/scripts/zoteroscihub.js
+++ b/chrome/content/scripts/zoteroscihub.js
@@ -127,7 +127,7 @@ Zotero.Scihub = {
 	generateItemUrl: function(item) {
 		var baseURL = Zotero.Prefs.get('zoteroscihub.scihub_url')
 		var DOI = item.getField('DOI').length > 0 ? item.getField('DOI') : item.getField('extra');
-		DOI = DOI.indexOf("\n")> -1 ? DOI.substring(0, DOI.indexOf("\n")).replace('DOI: ', '') : DOI.replace('DOI: ', '');
+		DOI = DOI.indexOf("\n")> -1 ? DOI.substring(DOI.indexOf('DOI: '), DOI.indexOf("\n", DOI.indexOf('DOI: '))).replace('DOI: ', '') : DOI.replace('DOI: ', '');
 		var url = "";
 		if(DOI && (typeof DOI == 'string') && DOI.length > 0) {
 			url = baseURL+'/'+DOI;


### PR DESCRIPTION
The DOI extracted from items only works if the DOI field is present. Some item types such as 'Book Section' does not have a DOI field, and was put into the Extra field. This change extracts the DOI from 'extra' field.