### PR TITLE
Fix Github Actions hack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
-    tags:
   pull_request:
-    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -14,8 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.3.0
@@ -41,10 +36,6 @@ jobs:
       - name: Build
         run: npm run build
       - name: Release
-        # Hack to set GITHUB_REF to the tag if current branch is tagged
-        run: |
-          if [ $(git describe --exact-match --tags) ]; then export GITHUB_REF=refs/tags/$(git describe --exact-match --tags); fi;
-          echo GITHUB_ACTIONS=$GITHUB_ACTIONS GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER GITHUB_REF=$GITHUB_REF GITHUB_SHA=$GITHUB_SHA GITHUB_EVENT_NAME=$GITHUB_EVENT_NAME
-          npm run release
+        run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "zotero-scihub",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.8",
+      "version": "1.0.9",
       "dependencies": {
         "@types/mocha": "^8.2.3",
         "@types/node": "^16.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zotero-scihub",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Download papers and books by DOI from Sci-Hub",
   "scripts": {
     "lint": "eslint . --ext .ts --cache --cache-location .eslintcache/",


### PR DESCRIPTION
As per discussion in https://github.com/retorquere/zotero-plugin-webpack/pull/16, the automated release builds on new version push (through `npm version <major|minor|patch>`) will work if your git is configured to push tags `git config --global push.followTags true`.

Also, currently `package.json` and `README.MD` point to my repository, you have to change it back to this one to enable automated releases (and then bump a patch version).

See release:
https://github.com/andrusha/zotero-scihub/releases/tag/v1.0.9

Workflow:
https://github.com/andrusha/zotero-scihub/runs/3176636852?check_suite_focus=true