### PR TITLE
updated query selector for pdf

### DIFF
--- a/content/scihub.ts
+++ b/content/scihub.ts
@@ -124,7 +124,7 @@ class Scihub {
     if (xhr.status === HttpCodes.DONE && pdfUrl) {
       const httpsUrl = UrlUtil.urlToHttps(pdfUrl)
       await ZoteroUtil.attachRemotePDFToItem(httpsUrl, item)
-    } else if (xhr.status === HttpCodes.DONE && body?.innerHTML?.match(/Please try to search again using DOI/im)) {
+    } else if (xhr.status === HttpCodes.DONE && body?.innerHTML === '') {
       Zotero.debug(`scihub: PDF is not available at the moment "${scihubUrl}"`)
       throw new PdfNotFoundError(`Pdf is not available: ${scihubUrl}`)
     } else {

--- a/content/scihub.ts
+++ b/content/scihub.ts
@@ -118,19 +118,30 @@ class Scihub {
     ZoteroUtil.showPopup('Fetching PDF', item.getField('title'))
 
     const xhr = await Zotero.HTTP.request('GET', scihubUrl.href, { responseType: 'document' })
+    // older .tf domains have iframe element, newer .st domain have embed element
     const pdfUrl = xhr.responseXML?.querySelector('#pdf')?.getAttribute('src')
     const body = xhr.responseXML?.querySelector('body')
 
     if (xhr.status === HttpCodes.DONE && pdfUrl) {
       const httpsUrl = UrlUtil.urlToHttps(pdfUrl)
       await ZoteroUtil.attachRemotePDFToItem(httpsUrl, item)
-    } else if (xhr.status === HttpCodes.DONE && body?.innerHTML === '') {
+    } else if (xhr.status === HttpCodes.DONE && this.isPdfNotAvailable(body)) {
       Zotero.debug(`scihub: PDF is not available at the moment "${scihubUrl}"`)
       throw new PdfNotFoundError(`Pdf is not available: ${scihubUrl}`)
     } else {
       Zotero.debug(`scihub: failed to fetch PDF from "${scihubUrl}"`)
       throw new Error(xhr.statusText)
     }
+  }
+
+  private isPdfNotAvailable(body: HTMLBodyElement | null | undefined): boolean {
+    const innerHTML = body?.innerHTML
+    // older .tf domain return rich error message
+    // newer .st domains return empty page if pdf is not available
+    if (!innerHTML || innerHTML?.trim() === '' || innerHTML?.match(/Please try to search again using DOI/im)) {
+      return true
+    }
+    return false
   }
 
   private getDoi(item: ZoteroItem): string | null {

--- a/content/scihub.ts
+++ b/content/scihub.ts
@@ -34,7 +34,7 @@ class ItemObserver implements ZoteroObserver {
 
 class Scihub {
   // TOOD: only bulk-update items which are missing paper attachement
-  private static readonly DEFAULT_SCIHUB_URL = 'https://sci-hub.tf/'
+  private static readonly DEFAULT_SCIHUB_URL = 'https://sci-hub.st/'
   private static readonly DEFAULT_AUTOMATIC_PDF_DOWNLOAD = true
   private observerId: number | null = null
   private initialized = false

--- a/content/scihub.ts
+++ b/content/scihub.ts
@@ -118,7 +118,7 @@ class Scihub {
     ZoteroUtil.showPopup('Fetching PDF', item.getField('title'))
 
     const xhr = await Zotero.HTTP.request('GET', scihubUrl.href, { responseType: 'document' })
-    const pdfUrl = xhr.responseXML?.querySelector('iframe#pdf')?.getAttribute('src')
+    const pdfUrl = xhr.responseXML?.querySelector('#pdf')?.getAttribute('src')
     const body = xhr.responseXML?.querySelector('body')
 
     if (xhr.status === HttpCodes.DONE && pdfUrl) {

--- a/locale/en-US/prefPane.dtd
+++ b/locale/en-US/prefPane.dtd
@@ -1,3 +1,3 @@
 <!ENTITY zotero.scihub.automatic_pdf_download "Automatic PDF Download">
-<!ENTITY zotero.scihub.scihub_url "Scihub URL: (Note https only works with sci-hub.tw due to invalid SSL certs on mirrors)">
+<!ENTITY zotero.scihub.scihub_url "Scihub URL:">
 <!ENTITY zotero.scihub.title "Zotero Scihub">

--- a/tests/scihub.test.ts
+++ b/tests/scihub.test.ts
@@ -27,19 +27,19 @@ describe('Scihub test', () => {
       // Allows sinon to enable FakeXHR module, since xhr is not available otherwise
       globalThis.XMLHttpRequest = FakeXMLHttpRequest
       server = fakeServer.create({ respondImmediately: true })
-      server.respondWith('GET', 'https://sci-hub.tf/10.1037/a0023781', [
+      server.respondWith('GET', 'https://sci-hub.st/10.1037/a0023781', [
         200, { 'Content-Type': 'text/html+xml' },
         '<html><body><iframe id="pdf" src="http://example.com/regular_item_1.pdf" /></body></html>',
       ])
-      server.respondWith('GET', 'https://sci-hub.tf/10.1029/2018JA025877', [
+      server.respondWith('GET', 'https://sci-hub.st/10.1029/2018JA025877', [
         200, { 'Content-Type': 'application/xml' },
         '<html><body><iframe id="pdf" src="https://example.com/doi_in_extra_item.pdf?param=val#tag" /></body></html>',
       ])
-      server.respondWith('GET', 'https://sci-hub.tf/10.1080/00224490902775827', [
+      server.respondWith('GET', 'https://sci-hub.st/10.1080/00224490902775827', [
         200, { 'Content-Type': 'application/xml' },
         '<html><body><iframe id="pdf" src="http://example.com/doi_in_url_item.pdf" /></body></html>',
       ])
-      server.respondWith('GET', 'https://sci-hub.tf/captcha', [
+      server.respondWith('GET', 'https://sci-hub.st/captcha', [
         200, { 'Content-Type': 'application/xml' },
         '<html><body>Captcha is required</body></html>',
       ])

--- a/tests/zoteroItem.mock.ts
+++ b/tests/zoteroItem.mock.ts
@@ -109,4 +109,19 @@ const captchaItem: ZoteroItem = new class {
   }
 }
 
-export { regularItem1, regularItem2, collectionItem, itemWithoutDOI, DOIinExtraItem, DOIinUrlItem, captchaItem }
+const unavailableItem: ZoteroItem = new class {
+  public isRegularItem() { return true }
+  public isCollection() { return false }
+  public libraryID = 'unavailableItemLibraryID2'
+  public id = '8'
+  public getField(f: string): any {
+    switch (f) {
+      case 'title': return 'unavailableItemTitle2'
+      case 'DOI': return '42.0/69'
+      case 'extra': return
+      case 'url': return
+    }
+  }
+}
+
+export { regularItem1, regularItem2, collectionItem, itemWithoutDOI, DOIinExtraItem, DOIinUrlItem, captchaItem, unavailableItem }


### PR DESCRIPTION
With the demise of the .tw domain and  an update to sci-hubs backend the query selector for pdfs changed from `iframe#pdf` to `#pdf`. Furthermore, for non available articles, the backend returns a blank page now. This merge request should fix [!57](https://github.com/ethanwillis/zotero-scihub/issues/57).