### PR TITLE
Add the latest official URL to as default

### DIFF
--- a/content/scihub.ts
+++ b/content/scihub.ts
@@ -34,7 +34,7 @@ class ItemObserver implements ZoteroObserver {
 
 class Scihub {
   // TOOD: only bulk-update items which are missing paper attachement
-  private static readonly DEFAULT_SCIHUB_URL = 'https://sci-hub.st/'
+  private static readonly DEFAULT_SCIHUB_URL = 'https://sci-hub.ru/'
   private static readonly DEFAULT_AUTOMATIC_PDF_DOWNLOAD = true
   private observerId: number | null = null
   private initialized = false

--- a/tests/scihub.test.ts
+++ b/tests/scihub.test.ts
@@ -27,23 +27,23 @@ describe('Scihub test', () => {
       // Allows sinon to enable FakeXHR module, since xhr is not available otherwise
       globalThis.XMLHttpRequest = FakeXMLHttpRequest
       server = fakeServer.create({ respondImmediately: true })
-      server.respondWith('GET', 'https://sci-hub.st/10.1037/a0023781', [
+      server.respondWith('GET', 'https://sci-hub.ru/10.1037/a0023781', [
         200, { 'Content-Type': 'text/html+xml' },
         '<html><body><iframe id="pdf" src="http://example.com/regular_item_1.pdf" /></body></html>',
       ])
-      server.respondWith('GET', 'https://sci-hub.st/10.1029/2018JA025877', [
+      server.respondWith('GET', 'https://sci-hub.ru/10.1029/2018JA025877', [
         200, { 'Content-Type': 'application/xml' },
         '<html><body><iframe id="pdf" src="https://example.com/doi_in_extra_item.pdf?param=val#tag" /></body></html>',
       ])
-      server.respondWith('GET', 'https://sci-hub.st/10.1080/00224490902775827', [
+      server.respondWith('GET', 'https://sci-hub.ru/10.1080/00224490902775827', [
         200, { 'Content-Type': 'application/xml' },
         '<html><body><embed id="pdf" src="http://example.com/doi_in_url_item.pdf"></embed></body></html>',
       ])
-      server.respondWith('GET', 'https://sci-hub.st/captcha', [
+      server.respondWith('GET', 'https://sci-hub.ru/captcha', [
         200, { 'Content-Type': 'application/xml' },
         '<html><body>Captcha is required</body></html>',
       ])
-      server.respondWith('GET', 'https://sci-hub.st/42.0/69', [
+      server.respondWith('GET', 'https://sci-hub.ru/42.0/69', [
         200, { 'Content-Type': 'application/xml' },
         '<html><body>Please try to search again using DOI</body></html>',
       ])


### PR DESCRIPTION
Also changed the Github test to accompany that. 

Alexandra also is not happy about 3rd party mirror, see [here](https://twitter.com/ringo_ring/status/1431376651691114501). `se` is one of the domains not `st` and also is banned in some countries.

Pretty sure that this pull request will trigger this repository existing action which will fail  [like me](https://github.com/MohamedElashri/zotero-scihub-1/actions/runs/1388559716) but the the new one [will pass](https://github.com/MohamedElashri/zotero-scihub-1/actions/runs/1388581372). 

And thank you for this amazing project.